### PR TITLE
Add support for JavaScriptCore

### DIFF
--- a/lib/stacktrace-parser.js
+++ b/lib/stacktrace-parser.js
@@ -9,7 +9,7 @@ var StackTraceParser = {
    */
   parse: function(stackString) {
     var chrome = /^\s*at (?:(?:(?:Anonymous function)?|((?:\[object object\])?\S+(?: \[as \S+\])?)) )?\(?((?:file|http|https):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
-        gecko = /^(?:\s*(\S*)(?:\((.*?)\))?@)?((?:file|http|https).*?):(\d+)(?::(\d+))?\s*$/i,
+        gecko = /^(?:\s*(\S*)(?:\((.*?)\))?@)?((?:\w).*?):(\d+)(?::(\d+))?\s*$/i,
         node  = /^\s*at (?:((?:\[object object\])?\S+(?: \[as \S+\])?) )?\(?(.*?):(\d+)(?::(\d+))?\)?\s*$/i,
         lines = stackString.split('\n'),
         stack = [],

--- a/test/stacktrace_parser_test.js
+++ b/test/stacktrace_parser_test.js
@@ -157,6 +157,30 @@ describe('StackTraceParser', function() {
             column: 580 } ]
       }
     ],
+    'JavaScriptCore': [
+      {
+        from: "timeoutWithName@stack_traces/test:83:55\nwrapped@bandage.js:51:30",
+        to: [ { file: 'stack_traces/test',
+            methodName: 'timeoutWithName',
+            lineNumber: 83,
+            column: 55 },
+          { file: 'bandage.js',
+            methodName: 'wrapped',
+            lineNumber: 51,
+            column: 30 } ]
+      },
+      {
+        from: "timeoutWithName@stack_traces/test:83:55\nwrapped@42start-with-number.js:51:30",
+        to: [ { file: 'stack_traces/test',
+            methodName: 'timeoutWithName',
+            lineNumber: 83,
+            column: 55 },
+          { file: '42start-with-number.js',
+            methodName: 'wrapped',
+            lineNumber: 51,
+            column: 30 } ]
+      }
+    ],
     'Internet Explorer': [
       {
         from: "Error: with timeout and named func\n   at timeoutWithName (http://bandage.jaz-lounge.com/stack_traces/test:83:9)\n   at wrapped (http://bandage.jaz-lounge.com/bandage.js:51:13)",


### PR DESCRIPTION
When using JSC API to `eval` a file, it can be given any filename, including the names without `file:///` or `http://` prefixes.
