### PR TITLE
Remove "engines" from package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
- - "0.10"
- - "0.12"
+ - "iojs"
  - "iojs-v2"
  - "iojs-v1"
+ - "0.12"
+ - "0.10"
+sudo: false

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "Parses every stack trace into a nicely formatted array of hashes.",
   "keywords": ["errors", "stacktrace", "parser", "exceptions"],
   "version": "0.1.2",
-  "engines": {
-    "node": "0.10 - 2"
-  },
   "dependencies": {},
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Node will soon be releasing a new major version several times a year so the engines field is getting outdated quickly, and this project doesn't depend on many features of Node anyway. This commit is to make it so that downstream projects like react-native don't print a warning when people install it with io.js 3.0, Node.js 4.0, etc.
