### PR TITLE
Allow spaces in function names

### DIFF
--- a/lib/stacktrace-parser.js
+++ b/lib/stacktrace-parser.js
@@ -9,7 +9,7 @@ var StackTraceParser = {
    */
   parse: function(stackString) {
     var chrome = /^\s*at (?:(?:(?:Anonymous function)?|((?:\[object object\])?\S+(?: \[as \S+\])?)) )?\(?((?:file|http|https):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
-        gecko = /^(?:\s*(\S*)(?:\((.*?)\))?@)?(\S.*?):(\d+)(?::(\d+))?\s*$/i,
+        gecko = /^(?:\s*([^@]*)(?:\((.*?)\))?@)?(\S.*?):(\d+)(?::(\d+))?\s*$/i,
         node  = /^\s*at (?:((?:\[object object\])?\S+(?: \[as \S+\])?) )?\(?(.*?):(\d+)(?::(\d+))?\)?\s*$/i,
         lines = stackString.split('\n'),
         stack = [],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "stacktrace-parser",
   "description": "Parses every stack trace into a nicely formatted array of hashes.",
   "keywords": ["errors", "stacktrace", "parser", "exceptions"],
-  "version": "0.1.3",
+  "version": "0.1.4",
   "dependencies": {},
   "devDependencies": {
     "mocha": "*",

--- a/test/stacktrace_parser_test.js
+++ b/test/stacktrace_parser_test.js
@@ -179,6 +179,13 @@ describe('StackTraceParser', function() {
             methodName: 'wrapped',
             lineNumber: 51,
             column: 30 } ]
+      },
+      {
+        from: "global code@stack_traces/test:83:55",
+        to: [ { file: 'stack_traces/test',
+            methodName: 'global code',
+            lineNumber: 83,
+            column: 55 } ]
       }
     ],
     'Internet Explorer': [


### PR DESCRIPTION
We are using stacktrace-parser on React Native, and with new JSC version the errors thrown in global scope are reported as having function name `global code`. Also it is possible to create a function with space in the name, so I suppose this PR will also be useful in that small number of edge cases.
