### PR TITLE
Fix Chrome Regex with Windows Paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stacktrace-parser",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/stack-trace-parser.js
+++ b/src/stack-trace-parser.js
@@ -23,7 +23,7 @@ export function parse(stackString) {
   }, []);
 }
 
-const chromeRe = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i;
+const chromeRe = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|\/|[a-z]:\\|\\\\).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i;
 const chromeEvalRe = /\((\S*)(?::(\d+))(?::(\d+))\)/;
 
 function parseChrome(line) {

--- a/test/fixtures/captured-errors.js
+++ b/test/fixtures/captured-errors.js
@@ -79,16 +79,19 @@ export default {
       '    at async foo (<anonymous>:2:3)',
   },
 
-  // can be generated when Webpack is built with { devtool: eval }
+  // can be generated when Webpack is built with source maps
   CHROME_XX_WEBPACK: {
     message: "Cannot read property 'error' of undefined",
     name: 'TypeError',
     stack:
       "TypeError: Cannot read property 'error' of undefined\n" +
+      // { devtool: eval }:
       '   at TESTTESTTEST.eval(webpack:///./src/components/test/test.jsx?:295:108)\n' +
       '   at TESTTESTTEST.render(webpack:///./src/components/test/test.jsx?:272:32)\n' +
       '   at TESTTESTTEST.tryRender(webpack:///./~/react-transform-catch-errors/lib/index.js?:34:31)\n' +
-      '   at TESTTESTTEST.proxiedMethod(webpack:///./~/react-proxy/modules/createPrototypeProxy.js?:44:30)',
+      '   at TESTTESTTEST.proxiedMethod(webpack:///./~/react-proxy/modules/createPrototypeProxy.js?:44:30)\n' +
+      // { devtool: source-map }:
+      '   at Module../pages/index.js (C:\\root\\server\\development\\pages\\index.js:182:7)',
   },
 
   FIREFOX_3: {

--- a/test/stack-trace-parser.spec.js
+++ b/test/stack-trace-parser.spec.js
@@ -641,7 +641,7 @@ describe('stackTraceParser', () => {
     const stackFrames = stackTraceParser.parse(
       CapturedExceptions.CHROME_XX_WEBPACK.stack
     );
-    expect(stackFrames.length).to.be(4);
+    expect(stackFrames.length).to.be(5);
     expect(stackFrames[0]).to.eql({
       file: 'webpack:///./src/components/test/test.jsx?',
       methodName: 'TESTTESTTEST.eval',
@@ -669,6 +669,13 @@ describe('stackTraceParser', () => {
       arguments: [],
       lineNumber: 44,
       column: 30,
+    });
+    expect(stackFrames[4]).to.eql({
+      file: 'C:\\root\\server\\development\\pages\\index.js',
+      methodName: 'Module../pages/index.js',
+      arguments: [],
+      lineNumber: 182,
+      column: 7,
     });
   });
 


### PR DESCRIPTION
Thanks for this awesome module! We're using it to build a new overlay for Next.js applications.

Our E2E tests found it failed to parse Chrome-generated errors with Windows paths.

This PR adds support for considering `C:\` or `\\` as the beginning of a Windows path (absolute path on local Filesystem, or a UNC path, respectively).

I've added an appropriate test case.

cc @ijjk

---

If you're curious what we're building:

![image](https://user-images.githubusercontent.com/616428/81244390-4e75a300-8fe0-11ea-902c-fb88da6ebdd0.png)
